### PR TITLE
Fix compiling: undefined refs of inline funcs

### DIFF
--- a/check_data.c
+++ b/check_data.c
@@ -5,7 +5,7 @@
 
 // Linux has no isnumber function? (Debian 4.0 has no such function)
 #ifndef isnumber
-inline int isnumber(char c) {
+extern inline int isnumber(char c) {
     return (isdigit(c) || c == '.' || c == '-');
 }
 #endif
@@ -13,7 +13,7 @@ inline int isnumber(char c) {
 #define MAX_CHAR_PREFIX_LENGTH 0xfff
 
 /*******************************************************************/
-inline ulonglong make_ulonglong(dulint x) {
+extern inline ulonglong make_ulonglong(dulint x) {
 	ulonglong lx = x.high;
 	lx <<= 32;
 	lx += x.low;
@@ -21,7 +21,7 @@ inline ulonglong make_ulonglong(dulint x) {
 }
 
 /*******************************************************************/
-inline longlong make_longlong(dulint x) {
+extern inline longlong make_longlong(dulint x) {
 	longlong lx = x.high;
 	lx <<= 32;
 	lx += x.low;
@@ -29,7 +29,7 @@ inline longlong make_longlong(dulint x) {
 }
 
 /*******************************************************************/
-inline ibool check_datetime(ulonglong ldate) {
+extern inline ibool check_datetime(ulonglong ldate) {
 	int year, month, day, hour, min, sec;
 
 	ldate &= ~(1ULL << 63);
@@ -71,7 +71,7 @@ inline ibool check_datetime(ulonglong ldate) {
 }
 
 /*******************************************************************/
-inline ibool check_char_ascii(char *value, ulint len) {
+extern inline ibool check_char_ascii(char *value, ulint len) {
 	char *p = value;
 	if (!len) return TRUE;
 	do {
@@ -81,7 +81,7 @@ inline ibool check_char_ascii(char *value, ulint len) {
 }
 
 /*******************************************************************/
-inline ibool check_char_digits(char *value, ulint len) {
+extern inline ibool check_char_digits(char *value, ulint len) {
 	char *p = value;
 	if (!len) return TRUE;
 	do {
@@ -96,7 +96,7 @@ inline ibool check_char_digits(char *value, ulint len) {
 // The function recomputes the regular expression per call. There is
 // no caching of regex. This can be optimized later on.
 /*******************************************************************/
-inline ibool regex_match(const char *string, char *pattern) {
+extern inline ibool regex_match(const char *string, char *pattern) {
 	int status;
 	regex_t re;
 	if(regcomp(&re, pattern, REG_EXTENDED|REG_NOSUB) != 0)
@@ -115,7 +115,7 @@ inline ibool regex_match(const char *string, char *pattern) {
 // statically allocated buffer; otherwise, allocate with malloc.
 // For long texts, this means a lot of overhead.
 /*******************************************************************/
-inline ibool check_regex_match(char *value, ulint len, char *pattern)
+extern inline ibool check_regex_match(char *value, ulint len, char *pattern)
 {
 	static char prefix[MAX_CHAR_PREFIX_LENGTH + 1];
 	char * null_terminated_value = NULL ;

--- a/print_data.c
+++ b/print_data.c
@@ -78,7 +78,7 @@ int guess_datetime_format(unsigned char* value){
 	return 0;
 	}
 
-inline void print_datetime(unsigned char* value, field_def_t *field) {
+extern inline void print_datetime(unsigned char* value, field_def_t *field) {
 	int year, month, day, hour, min, sec;
 	int format = guess_datetime_format(value);
 	if(format == 1 || format == 0){
@@ -150,7 +150,7 @@ void print_hex(char *value, ulint len) {
 }
 
 /*******************************************************************/
-inline void print_date(ulong ldate) {
+extern inline void print_date(ulong ldate) {
 	int year, month, day;
 
 	ldate &= ~(1UL << 23);
@@ -163,7 +163,7 @@ inline void print_date(ulong ldate) {
 }
 
 /*******************************************************************/
-inline void print_time(unsigned char* value, field_def_t *field) {
+extern inline void print_time(unsigned char* value, field_def_t *field) {
 	int hour, min, sec;
 	ulong ltime = mach_read_from_3(value);
 	
@@ -189,13 +189,13 @@ inline void print_time(unsigned char* value, field_def_t *field) {
 
 
 /*******************************************************************/
-inline void print_enum(int value, field_def_t *field) {
+extern inline void print_enum(int value, field_def_t *field) {
 	fprintf(f_result, "%d", value);
 	//fprintf(f_result, "\"%s\"", field->limits.enum_values[value-1]);
 }
 
 /*******************************************************************/
-inline void print_set(int value, field_def_t *field) {
+extern inline void print_set(int value, field_def_t *field) {
   /*    int i;
          int comma = 0
 	fprintf(f_result, "\"");
@@ -212,7 +212,7 @@ inline void print_set(int value, field_def_t *field) {
 }
 
 /*******************************************************************/
-inline unsigned long long int get_uint_value(field_def_t *field, byte *value) {
+extern inline unsigned long long int get_uint_value(field_def_t *field, byte *value) {
 	switch (field->fixed_length) {
 		case 1: return mach_read_from_1(value);
 		case 2: return mach_read_from_2(value);
@@ -227,7 +227,7 @@ inline unsigned long long int get_uint_value(field_def_t *field, byte *value) {
 }
 
 /*******************************************************************/
-inline long long int get_int_value(field_def_t *field, byte *value) {
+extern inline long long int get_int_value(field_def_t *field, byte *value) {
 	char v1;
 	short int v2;
 	int v3, v4;
@@ -255,7 +255,7 @@ inline long long int get_int_value(field_def_t *field, byte *value) {
 }
 
 /*******************************************************************/
-inline void print_string(char *value, ulint len, field_def_t *field) {
+extern inline void print_string(char *value, ulint len, field_def_t *field) {
     uint i, num_spaces = 0, out_pos = 0;
     static char out[32768];
     
@@ -317,7 +317,7 @@ size_t strip_space(const char* str_in, char* str_out){
 }
 
 /*******************************************************************/
-inline void print_decimal(byte *value, field_def_t *field) {
+extern inline void print_decimal(byte *value, field_def_t *field) {
     char string_buf[256];
     char string_buf2[256];
     decimal_digit_t dec_buf[256];
@@ -334,7 +334,7 @@ inline void print_decimal(byte *value, field_def_t *field) {
 }
 
 /*******************************************************************/
-inline void print_field_value(byte *value, ulint len, field_def_t *field) {
+extern inline void print_field_value(byte *value, ulint len, field_def_t *field) {
   /* time_t t;*/
 
 	switch (field->type) {

--- a/stream_parser.c
+++ b/stream_parser.c
@@ -293,7 +293,7 @@ void show_progress(off64_t offset, off64_t length){
     return;
 }
 
-inline void process_ibpage(page_t* page){
+extern inline void process_ibpage(page_t* page){
     uint32_t page_id = mach_read_from_4(page + FIL_PAGE_OFFSET);
     uint64_t index_id = mach_read_from_8(page + PAGE_HEADER + PAGE_INDEX_ID);
     uint16_t page_type = mach_read_from_2(page + FIL_PAGE_TYPE);


### PR DESCRIPTION
Example of the error:
```
cc -D_FILE_OFFSET_BITS=64 -Wall -g -O3 -pipe  -I./include  -pthread -lm  stream_parser.o -o stream_parser
/bin/ld: stream_parser.o: in function `process_ibfile':
/home/n0t/git/fork/undrop-for-innodb/stream_parser.c:382: undefined reference to `process_ibpage'
collect2: error: ld returned 1 exit status
make: *** [Makefile:31: stream_parser] Error 1
```